### PR TITLE
Use reusable workflow from main :smile_cat: 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         run: echo "true"
 
   call-test:
-    uses: airtower-luna/hello-github-actions/.github/workflows/reusable-echo.yaml@reusable-workflow
+    uses: airtower-luna/hello-github-actions/.github/workflows/reusable-echo.yaml@main
     with:
       test: |
         Hello World!


### PR DESCRIPTION
Only after this I can safely delete the "reusable-workflow" branch,
contrary to what the PR GUI claims in #17.