### PR TITLE
Call reusable workflow from HEAD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
         run: echo "true"
 
   call-test:
-    uses: airtower-luna/hello-github-actions/.github/workflows/reusable-echo.yaml@main
+    uses: ./.github/workflows/reusable-echo.yaml
     with:
       test: |
         Hello World!


### PR DESCRIPTION
This should work [as of yesterday](https://github.blog/changelog/2022-01-25-github-actions-reusable-workflows-can-be-referenced-locally/). :smile_cat: