### PR TITLE
Test Dependabot updates for pinned versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      day: 'saturday'
+      day: 'thursday'
   # Docker checks don't work recursively, so list both directories.
   - package-ecosystem: 'docker'
     directory: '/action-a'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
     name: Hello World action
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
       - name: Check Python paths
         run: |
           for p in python python3 /usr/bin/python3; do


### PR DESCRIPTION
I'm intentionally pinning a slightly older version of actions/checkout to see if the update works like it should.

See: https://github.com/dependabot/dependabot-core/issues/4691