### PR TITLE
Use ubuntu-latest runner to avoid old images

### DIFF
--- a/.github/workflows/httpd.yaml
+++ b/.github/workflows/httpd.yaml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: debian:bullseye
     services:
       apache:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: push
 jobs:
   build:
     name: Hello World action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Check Python paths
@@ -55,7 +55,7 @@ jobs:
 
   process-event:
     name: Process event data
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: show event, set tag
         id: gen-tag

--- a/.github/workflows/multiline-output.yaml
+++ b/.github/workflows/multiline-output.yaml
@@ -3,7 +3,7 @@ on: push
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: define list
         id: files
@@ -30,7 +30,7 @@ jobs:
           LIST: ${{ steps.lines.outputs.list }}
 
   multiple_outputs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: set outputs
         id: colors


### PR DESCRIPTION
The examples shouldn't require specific versions.